### PR TITLE
Extend API configuration add schema factory

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -10,4 +10,16 @@
     <rule ref="Squiz.Commenting.VariableComment.WrongStyle">
         <exclude name="Squiz.Commenting.VariableComment.WrongStyle"/>
     </rule>
+
+    <rule ref="Squiz.Commenting.FunctionComment.Missing">
+        <exclude-pattern>*tests/cases/*</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+        <exclude-pattern>*tests/cases/*</exclude-pattern>
+    </rule>
+
+    <rule ref="Squiz.Classes.ClassFileName.NoMatch">
+        <exclude-pattern>*tests/cases/*</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/DI/OpenApiPlugin.php
+++ b/src/DI/OpenApiPlugin.php
@@ -5,6 +5,11 @@ namespace Apitte\OpenApi\DI;
 use Apitte\Core\DI\Plugin\AbstractPlugin;
 use Apitte\Core\DI\Plugin\PluginCompiler;
 use Apitte\OpenApi\OpenApiService;
+use Apitte\OpenApi\Schema\Contact;
+use Apitte\OpenApi\Schema\Info;
+use Apitte\OpenApi\Schema\License;
+use Apitte\OpenApi\SchemaType\BaseSchemaType;
+use Apitte\OpenApi\SchemaType\ISchemaType;
 use Apitte\OpenApi\Tracy\SwaggerUIPanel;
 use Nette\PhpGenerator\ClassType;
 
@@ -20,6 +25,15 @@ class OpenApiPlugin extends AbstractPlugin
 			'expansion' => SwaggerUIPanel::EXPANSION_LIST,
 			'filter' => TRUE,
 			'title' => 'OpenAPI',
+			'panel' => TRUE,
+		],
+		'info' => [
+			'title' => 'Api Docs',
+			'description' => NULL,
+			'termsOfService' => NULL,
+			'contact' => NULL,
+			'license' => NULL,
+			'version' => '2.0.5-beta',
 		],
 	];
 
@@ -43,18 +57,64 @@ class OpenApiPlugin extends AbstractPlugin
 		$global = $this->compiler->getExtension()->getConfig();
 		$config = $this->getConfig();
 
+		$infoContact = NULL;
+		if ($config['info']['contact'] !== NULL) {
+			$builder->addDefinition($this->prefix('openapi.info.contact'))
+				->setType(Contact::class)
+				->setFactory(Contact::class, [
+						$config['info']['contact']['name'],
+						$config['info']['contact']['url'],
+						$config['info']['contact']['email'],
+					])
+				->setAutowired(FALSE);
+
+			$infoContact = '@' . $this->prefix('openapi.info.contact');
+		}
+
+		$infoLicense = NULL;
+		if ($config['info']['license'] !== NULL) {
+			$builder->addDefinition($this->prefix('openapi.info.license'))
+				->setType(License::class)
+				->setFactory(License::class, [
+						$config['info']['license'],
+					])
+				->setAutowired(FALSE);
+
+			$infoLicense = '@' . $this->prefix('openapi.info.license');
+		}
+
+		$builder->addDefinition($this->prefix('openapi.info'))
+			->setType(Info::class)
+			->setFactory(Info::class, [
+				$config['info']['title'],
+				$config['info']['description'],
+				$config['info']['termsOfService'],
+				$infoContact,
+				$infoLicense,
+				$config['info']['version'],
+			])
+			->setAutowired(FALSE);
+
+		$builder->addDefinition('openapi.schemaType')
+            ->setType(ISchemaType::class)
+            ->setFactory(BaseSchemaType::class);
+
 		$builder->addDefinition($this->prefix('openapi'))
-			->setFactory(OpenApiService::class);
+			->setFactory(OpenApiService::class, [
+				1 => '@' . $this->prefix('openapi.info'),
+			]);
 
 		if ($global['debug'] !== TRUE) return;
 
-		$builder->addDefinition($this->prefix('swagger.panel'))
-			->setFactory(SwaggerUIPanel::class)
-			->addSetup('setUrl', [$config['swagger']['url']])
-			->addSetup('setExpansion', [$config['swagger']['expansion']])
-			->addSetup('setFilter', [$config['swagger']['filter']])
-			->addSetup('setTitle', [$config['swagger']['title']])
-			->setAutowired(FALSE);
+		if ($config['swagger']['panel']) {
+			$builder->addDefinition($this->prefix('swagger.panel'))
+				->setFactory(SwaggerUIPanel::class)
+				->addSetup('setUrl', [$config['swagger']['url']])
+				->addSetup('setExpansion', [$config['swagger']['expansion']])
+				->addSetup('setFilter', [$config['swagger']['filter']])
+				->addSetup('setTitle', [$config['swagger']['title']])
+				->setAutowired(FALSE);
+		}
 	}
 
 	/**
@@ -63,11 +123,15 @@ class OpenApiPlugin extends AbstractPlugin
 	 */
 	public function afterPluginCompile(ClassType $class)
 	{
-		$config = $this->compiler->getExtension()->getConfig();
-		if ($config['debug'] !== TRUE) return;
+		$global = $this->compiler->getExtension()->getConfig();
+		if ($global['debug'] !== TRUE) return;
+
+		$config = $this->getConfig();
 
 		$initialize = $class->getMethod('initialize');
-		$initialize->addBody('$this->getService(?)->addPanel($this->getService(?));', ['tracy.bar', $this->prefix('swagger.panel')]);
+		if ($config['swagger']['panel']) {
+			$initialize->addBody('$this->getService(?)->addPanel($this->getService(?));', ['tracy.bar', $this->prefix('swagger.panel')]);
+		}
 	}
 
 }

--- a/src/Schema/Contact.php
+++ b/src/Schema/Contact.php
@@ -15,6 +15,18 @@ class Contact implements IOpenApiObject
 	private $email;
 
 	/**
+	 * @param string|null $name
+	 * @param string|null $url
+	 * @param string|null $email
+	 */
+	public function __construct($name, $url, $email)
+	{
+		$this->name = $name;
+		$this->url = $url;
+		$this->email = $email;
+	}
+
+	/**
 	 * @return mixed[]
 	 */
 	public function toArray()

--- a/src/Schema/Info.php
+++ b/src/Schema/Info.php
@@ -25,11 +25,26 @@ class Info implements IOpenApiObject
 
 	/**
 	 * @param string $title
+	 * @param string|NULL $description
+	 * @param string|NULL $termsOfService
+	 * @param Contact|NULL $contact
+	 * @param License|NULL $license
 	 * @param string $version
 	 */
-	public function __construct($title, $version)
+	public function __construct(
+		$title,
+		$description = NULL,
+		$termsOfService = NULL,
+		Contact $contact = NULL,
+		License $license = NULL,
+		$version
+	)
 	{
 		$this->title = $title;
+		$this->description = $description;
+		$this->termsOfService = $termsOfService;
+		$this->contact = $contact;
+		$this->license = $license;
 		$this->version = $version;
 	}
 

--- a/src/SchemaType/BaseSchemaType.php
+++ b/src/SchemaType/BaseSchemaType.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Apitte\OpenApi\SchemaType;
+
+use Apitte\Core\Schema\EndpointParameter;
+use Apitte\OpenApi\Schema\Schema;
+
+final class BaseSchemaType implements ISchemaType
+{
+
+	/**
+	 * @param EndpointParameter $endpointParameter
+	 *
+	 * @return Schema
+	 */
+	public function createSchema(EndpointParameter $endpointParameter)
+	{
+		switch ($endpointParameter->getType()) {
+			case EndpointParameter::TYPE_SCALAR:
+				return new Schema(
+					[
+						'type' => 'scalar',
+					]
+				);
+
+			case EndpointParameter::TYPE_STRING:
+				return new Schema(
+					[
+						'type' => 'string',
+					]
+				);
+
+			case EndpointParameter::TYPE_INTEGER:
+				return new Schema(
+					[
+						'type'   => 'integer',
+						'format' => 'int32',
+					]
+				);
+
+			case EndpointParameter::TYPE_FLOAT:
+				return new Schema(
+					[
+						'type'   => 'float',
+						'format' => 'float64',
+					]
+				);
+
+			case EndpointParameter::TYPE_BOOLEAN:
+				return new Schema(
+					[
+						'type' => 'boolean',
+					]
+				);
+
+			case EndpointParameter::TYPE_DATETIME:
+				return new Schema(
+					[
+						'type'   => 'string',
+						'format' => 'date-time',
+					]
+				);
+
+			case EndpointParameter::TYPE_OBJECT:
+				return new Schema(
+					[
+						'type' => 'object',
+					]
+				);
+
+			default:
+				throw new UnknownSchemaType('Unknown endpoint parameter type ' . $endpointParameter->getType());
+		}
+	}
+
+}

--- a/src/SchemaType/ISchemaType.php
+++ b/src/SchemaType/ISchemaType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Apitte\OpenApi\SchemaType;
+
+use Apitte\Core\Schema\EndpointParameter;
+use Apitte\OpenApi\Schema\Schema;
+
+interface ISchemaType
+{
+
+	/**
+	 * @param EndpointParameter $endpointParameter
+	 *
+	 * @return Schema
+	 */
+	public function createSchema(EndpointParameter $endpointParameter);
+
+}

--- a/src/SchemaType/UnknownSchemaType.php
+++ b/src/SchemaType/UnknownSchemaType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Apitte\OpenApi\SchemaType;
+
+use InvalidArgumentException;
+
+class UnknownSchemaType extends InvalidArgumentException
+{
+
+}

--- a/tests/cases/SchemaType/BaseSchemaType.phpt
+++ b/tests/cases/SchemaType/BaseSchemaType.phpt
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * Test: SchemaType\BaseSchemaType
+ */
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+use Apitte\Core\Schema\EndpointParameter;
+use Apitte\OpenApi\Schema\Schema;
+use Apitte\OpenApi\SchemaType\BaseSchemaType;
+use Apitte\OpenApi\SchemaType\ISchemaType;
+use Apitte\OpenApi\SchemaType\UnknownSchemaType;
+use Tester\Assert;
+use Tester\TestCase;
+
+final class TestBaseSchemaType extends TestCase
+{
+
+	/**
+	 * @var ISchemaType
+	 */
+	private $baseSchemaType;
+
+	protected function setUp()
+	{
+		$this->baseSchemaType = new BaseSchemaType;
+	}
+
+	public function testScalar()
+	{
+		$endpointParameter = new EndpointParameter;
+		$endpointParameter->setType(EndpointParameter::TYPE_SCALAR);
+
+		$scalarSchema = $this->baseSchemaType->createSchema($endpointParameter);
+
+		Assert::type(Schema::class, $scalarSchema);
+		Assert::same(
+			[
+				'type' => 'scalar',
+			],
+			$scalarSchema->toArray()
+		);
+	}
+
+	public function testString()
+	{
+		$endpointParameter = new EndpointParameter;
+		$endpointParameter->setType(EndpointParameter::TYPE_STRING);
+
+		$scalarSchema = $this->baseSchemaType->createSchema($endpointParameter);
+
+		Assert::type(Schema::class, $scalarSchema);
+		Assert::same(
+			[
+				'type' => 'string',
+			],
+			$scalarSchema->toArray()
+		);
+	}
+
+	public function testInteger()
+	{
+		$endpointParameter = new EndpointParameter;
+		$endpointParameter->setType(EndpointParameter::TYPE_INTEGER);
+
+		$scalarSchema = $this->baseSchemaType->createSchema($endpointParameter);
+
+		Assert::type(Schema::class, $scalarSchema);
+		Assert::same(
+			[
+				'type'   => 'integer',
+				'format' => 'int32',
+			],
+			$scalarSchema->toArray()
+		);
+	}
+
+	public function testFloat()
+	{
+		$endpointParameter = new EndpointParameter;
+		$endpointParameter->setType(EndpointParameter::TYPE_FLOAT);
+
+		$scalarSchema = $this->baseSchemaType->createSchema($endpointParameter);
+
+		Assert::type(Schema::class, $scalarSchema);
+		Assert::same(
+			[
+				'type'   => 'float',
+				'format' => 'float64',
+			],
+			$scalarSchema->toArray()
+		);
+	}
+
+	public function testBoolean()
+	{
+		$endpointParameter = new EndpointParameter;
+		$endpointParameter->setType(EndpointParameter::TYPE_BOOLEAN);
+
+		$scalarSchema = $this->baseSchemaType->createSchema($endpointParameter);
+
+		Assert::type(Schema::class, $scalarSchema);
+		Assert::same(
+			[
+				'type' => 'boolean',
+			],
+			$scalarSchema->toArray()
+		);
+	}
+
+	public function testDatetime()
+	{
+		$endpointParameter = new EndpointParameter;
+		$endpointParameter->setType(EndpointParameter::TYPE_DATETIME);
+
+		$scalarSchema = $this->baseSchemaType->createSchema($endpointParameter);
+
+		Assert::type(Schema::class, $scalarSchema);
+		Assert::same(
+			[
+				'type'   => 'string',
+				'format' => 'date-time',
+			],
+			$scalarSchema->toArray()
+		);
+	}
+
+	public function testObject()
+	{
+		$endpointParameter = new EndpointParameter;
+		$endpointParameter->setType(EndpointParameter::TYPE_OBJECT);
+
+		$scalarSchema = $this->baseSchemaType->createSchema($endpointParameter);
+
+		Assert::type(Schema::class, $scalarSchema);
+		Assert::same(
+			[
+				'type' => 'object',
+			],
+			$scalarSchema->toArray()
+		);
+	}
+
+	public function testUnknownType()
+	{
+		$endpointParameter = new EndpointParameter;
+		$endpointParameter->setType('barBaz');
+
+		Assert::throws(function () use ($endpointParameter) {
+			$this->baseSchemaType->createSchema($endpointParameter);
+		}, UnknownSchemaType::class, 'Unknown endpoint parameter type barBaz');
+	}
+
+}
+
+(new TestBaseSchemaType)->run();


### PR DESCRIPTION
This PR adds:
- support for changing `Info` DTO in `OpenApiService`,
- introduce `SchemaType\Factory` (instead of creating Schema with 'integer' type)
- ~enable new `tracy/tracy`~