### PR TITLE
OpenApiService: export multi method on single path

### DIFF
--- a/src/OpenApiService.php
+++ b/src/OpenApiService.php
@@ -44,7 +44,11 @@ class OpenApiService
 		foreach ($this->getEndpoints() as $endpoint) {
 			$endpointId++;
 
-			$pathItem = new PathItem();
+			$pathItem = $paths->getPath($endpoint->getMask());
+			if ($pathItem === NULL) {
+				$pathItem = new PathItem();
+			}
+
 			foreach ($endpoint->getMethods() as $method) {
 
 				//Request MediaType

--- a/src/Schema/Paths.php
+++ b/src/Schema/Paths.php
@@ -19,6 +19,16 @@ class Paths implements IOpenApiObject
 	}
 
 	/**
+	 * @param string $path
+	 *
+	 * @return PathItem|null
+	 */
+	public function getPath($path)
+	{
+		return array_key_exists($path, $this->paths) ? $this->paths[$path] : NULL;
+	}
+
+	/**
 	 * @return mixed[]
 	 */
 	public function toArray()


### PR DESCRIPTION
This PR extend exist `pathItem` instead of replacing it.