### PR TITLE
Read correct type for endpoint parameters

### DIFF
--- a/src/SchemaDefinition/CoreDefinition.php
+++ b/src/SchemaDefinition/CoreDefinition.php
@@ -153,7 +153,7 @@ class CoreDefinition implements IDefinition
 			$parameter['description'] = $parameterDescription;
 		}
 		$parameter['required'] = $endpointParameter->isRequired();
-		$parameter['schema'] = ['type' => 'string'];
+		$parameter['schema'] = ['type' => $endpointParameter->getType()];
 
 		// $param->setAllowEmptyValue($endpointParam->isAllowEmpty());
 		// $param->setDeprecated($endpointParam->isDeprecated());


### PR DESCRIPTION
Currently, all endpoint parameters are presented as strings. This should fix that :-)