### PR TITLE
Fix getcomposer link domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Website ðŸš€ <a href="https://contributte.org">contributte.org</a> | Contact ðŸ‘
 
 ## Usage
 
-To install the latest version of `apitte/openapi` use [Composer](https://getcomposer.com).
+To install the latest version of `apitte/openapi` use [Composer](https://getcomposer.org).
 
 ```bash
 composer require apitte/openapi


### PR DESCRIPTION
Fix getcomposer.com to correct domain getcomposer.org.