### PR TITLE
Changed getType to getSchemaType from apitte/core schema changes

### DIFF
--- a/src/SchemaDefinition/CoreDefinition.php
+++ b/src/SchemaDefinition/CoreDefinition.php
@@ -157,7 +157,7 @@ class CoreDefinition implements IDefinition
 		}
 
 		$parameter['required'] = $endpointParameter->isRequired();
-		$parameter['schema'] = ['type' => $endpointParameter->getType()];
+		$parameter['schema'] = ['type' => $endpointParameter->getSchemaType()];
 
 		// $param->setAllowEmptyValue($endpointParam->isAllowEmpty());
 		// $param->setDeprecated($endpointParam->isDeprecated());


### PR DESCRIPTION
Hello,

i added this dependent PR on https://github.com/contributte/apitte-core/pull/7

It using new method "getSchemaType" in EndpointParameter from my other PR, that returns int as integer and bool as boolean.

![image](https://user-images.githubusercontent.com/7610662/179980972-8cded8d0-6e70-4ac2-8f27-31a2f3f7ee89.png)
