### PR TITLE
fix: correct packagist URL format

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | :warning: | This project is no longer being maintained. Please use [contributte/apitte](https://github.com/contributte/apitte).|
 |---|---|
 
-| Composer | [`apitte/openapi`](https://packagist.org/apitte/openapi) |
+| Composer | [`apitte/openapi`](https://packagist.org/packages/apitte/openapi) |
 |---| --- |
 | Version | ![](https://badgen.net/packagist/v/apitte/openapi) |
 | PHP | ![](https://badgen.net/packagist/php/apitte/openapi) |


### PR DESCRIPTION
Fixes the packagist URL in the Composer package table to use the correct format with `/packages/` path.

Changes:
- Update packagist URL from `https://packagist.org/apitte/openapi` to `https://packagist.org/packages/apitte/openapi`

This ensures the link correctly points to the package page on Packagist.